### PR TITLE
Add IN query to quick filters

### DIFF
--- a/src/components/QueryEditor/FilterEditor/index.tsx
+++ b/src/components/QueryEditor/FilterEditor/index.tsx
@@ -130,10 +130,23 @@ export const FilterEditorRow = ({ value, onSubmit }: FilterEditorRowProps) => {
             }}
           />
         </div>
-        {!['exists', 'not exists'].includes(value.filter.operator) && (
+        {['=', '!=', 'term', 'not term'].includes(value.filter.operator) && (
           <Input
             ref={valueInputRef}
             placeholder="Value"
+            value={value.filter.value}
+            onChange={(e) => dispatch(changeFilterValue({ id: value.id, value: e.currentTarget.value }))}
+            onKeyUp={(e) => {
+              if (e.key === 'Enter') {
+                onSubmit();
+              }
+            }}
+          />
+        )}
+        {['in', 'not in'].includes(value.filter.operator) && (
+          <Input
+            ref={valueInputRef}
+            placeholder="Space-delimited values"
             value={value.filter.value}
             onChange={(e) => dispatch(changeFilterValue({ id: value.id, value: e.currentTarget.value }))}
             onKeyUp={(e) => {

--- a/src/datasource/base.ts
+++ b/src/datasource/base.ts
@@ -394,7 +394,10 @@ export class BaseQuickwitDataSource
     if (!adhocFilters) {
       return query;
     }
-    let finalQuery = query;
+
+    // Surround the query with () to ensure that the filters are properly AND'd
+    let finalQuery = '(' + query + ')';
+
     adhocFilters.forEach((filter) => {
       finalQuery = addAddHocFilter(finalQuery, filter);
     });

--- a/src/modifyQuery.ts
+++ b/src/modifyQuery.ts
@@ -52,6 +52,24 @@ export function addAddHocFilter(query: string, filter: AdHocVariableFilter): str
     case 'not exists':
       addHocFilter = `-${key}:*`;
       break;
+    case 'in':
+      addHocFilter = createAdhocFilterIn(key, value);
+      break;
+    case 'not in':
+      addHocFilter = `(NOT (${createAdhocFilterIn(key, value)}))`;
+      break;
   }
   return concatenate(query, addHocFilter);
+}
+
+function createAdhocFilterIn(key: string, value: string): string {
+  const values = value.split(' ');
+
+  // OR is faster than IN for smaller number of values
+  if (values.length < 10) {
+    const conditions = values.map(v => `${key}:${v}`);
+    return `(${conditions.join(' OR ')})`;
+  }
+
+  return `${key}:IN [${value}]`;
 }

--- a/src/queryDef.ts
+++ b/src/queryDef.ts
@@ -44,6 +44,8 @@ export const filterOperations = [
   { label: 'not term', value: 'not term' },
   { label: 'exists', value: 'exists' },
   { label: 'not exists', value: 'not exists' },
+  { label: 'in', value: 'in' },
+  { label: 'not in', value: 'not in' },
 ];
 
 export function defaultFilter(id = newFilterId()): QueryFilter {


### PR DESCRIPTION
Changes:
  - Added `in` and `not in` query types in quick filter
  - Surround the hand-written lucene query in brackets to properly AND it with the quick filter terms