### PR TITLE
Fix query failure when the Lucene Query field is empty

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quickwit-datasource",
-  "version": "0.8.0+paypay",
+  "version": "0.8.1+paypay",
   "description": "Quickwit datasource",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/src/datasource/base.ts
+++ b/src/datasource/base.ts
@@ -396,7 +396,10 @@ export class BaseQuickwitDataSource
     }
 
     // Surround the query with () to ensure that the filters are properly AND'd
-    let finalQuery = '(' + query + ')';
+    let finalQuery = query.trim();
+    if (finalQuery.length > 0) {
+      finalQuery = '(' + finalQuery + ')';
+    }
 
     adhocFilters.forEach((filter) => {
       finalQuery = addAddHocFilter(finalQuery, filter);


### PR DESCRIPTION
Currently the rendered query may look something like `()` or `() env:prod` which is not a valid Lucene query. Also bumped the version to v0.8.1.